### PR TITLE
docs: add missing email env variables

### DIFF
--- a/en/deploy/env.mdx
+++ b/en/deploy/env.mdx
@@ -39,6 +39,9 @@ mode: "wide"
 | BACKEND_MAIL_PORT                          | Email server port                                                         | -               | -        | 465                                               |
 | BACKEND_MAIL_AUTH_USER                     | Email server authentication username                                       | -               | -        | username                                          |
 | BACKEND_MAIL_AUTH_PASS                     | Email server authentication password                                       | -               | -        | usertoken                                         |
+| BACKEND_MAIL_SECURE                        | Email smtp use SSL (SMTP-Server has to support this)                       | true            | -        | true                                              |
+| BACKEND_MAIL_SENDER                        | Email address which gets used for sending mails                            | noreply.teable.io | -      | mymail@example.com                                |
+| BACKEND_MAIL_SENDER_NAME                   | Email sender name which gets displayed in sent mails                       | Teable          | -        | Teable                                            |
 | Session/JWT Configuration                                                                                               |
 | BACKEND_SESSION_EXPIRES_IN                 | Session expiration time                                                   | 7d              | -        | 7d                                                |
 | BACKEND_SESSION_COOKIE_SECURE              | Whether to secure session cookie                                         | false           | -        | true                                              |


### PR DESCRIPTION
Add 3 missing environment variables in the documentation. They are named in the tab for setting up email, but not in the list of all environment variables.