### PR TITLE
docs: add OIDC link to SSO documentation

### DIFF
--- a/zh/basic/organization/sso.mdx
+++ b/zh/basic/organization/sso.mdx
@@ -7,7 +7,7 @@ description: "集成单点登录 SSO，支持标准OIDC和飞书"
 
 支持的 SSO Provider
 
-* 标准OIDC
+* [标准OIDC](/zh/deploy/oidc)
 * 飞书
 
 <Card title="注意" horizontal>


### PR DESCRIPTION
  - Convert 'OIDC' text to clickable link in SSO docs
  - Link redirects to /zh/deploy/oidc detailed documentation
  - Enhance user navigation and access to OIDC setup guide