### PR TITLE
docs: add upgrade guide for self-hosted deployment

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -244,6 +244,7 @@
                   "en/deploy/docker",
                   "en/deploy/one-key",
                   "en/deploy/k8s",
+                  "en/deploy/upgrade",
                   "en/deploy/architecture"
                 ]
               },
@@ -517,6 +518,7 @@
                   "zh/deploy/docker",
                   "zh/deploy/one-key",
                   "zh/deploy/k8s",
+                  "zh/deploy/upgrade",
                   "zh/deploy/architecture"
                 ]
               },

--- a/en/deploy/upgrade.mdx
+++ b/en/deploy/upgrade.mdx
@@ -1,0 +1,198 @@
+---
+title: "Version Upgrade"
+---
+
+This document describes how to upgrade your self-hosted Teable deployment.
+
+## Update Frequency
+
+You have full control over when to update your self-hosted Teable instance. Whenever a new version is released, you can flexibly choose whether to upgrade. You can view all available versions on [GitHub Packages](https://github.com/teableio/teable-enterprise/pkgs/container/teable-ee).
+
+<Tip>
+If you need to ensure stability, we recommend only updating to versions with the `stable` tag.
+</Tip>
+
+<Note>
+Before performing any upgrade, we strongly recommend backing up your data first.
+</Note>
+
+## Docker Compose Upgrade
+
+If you deployed Teable using Docker Compose, follow these steps to upgrade:
+
+### 1. Backup Data (Recommended)
+
+Before upgrading, we recommend backing up your important data:
+
+**Backup PostgreSQL database:**
+
+```bash
+docker exec teable-db pg_dump -U teable teable > backup_$(date +%Y%m%d).sql
+```
+
+**Backup attachment data:**
+
+```bash
+docker run --rm -v teable-data:/data -v $(pwd):/backup alpine tar czf /backup/teable-data_$(date +%Y%m%d).tar.gz /data
+```
+
+### 2. Navigate to Deployment Directory
+
+```bash
+cd teable  # Navigate to your teable deployment directory
+```
+
+### 3. Pull Latest Images
+
+```bash
+docker-compose pull
+```
+
+### 4. Restart Services
+
+```bash
+docker-compose up -d
+```
+
+The system will automatically recreate containers using the latest images. Your data is stored in Docker volumes and will not be lost.
+
+### 5. Verify Upgrade
+
+```bash
+# Check container status
+docker-compose ps
+
+# View logs to confirm successful startup
+docker-compose logs -f teable
+```
+
+Visit your Teable instance to confirm the service is running properly.
+
+## Upgrade to Specific Version
+
+If you want to upgrade to a specific version instead of the latest, modify the image tag in `docker-compose.yaml`:
+
+```yaml
+services:
+  teable:
+    image: ghcr.io/teableio/teable-ee:0.5.0-alpha-1.x.x-build.xxx  # Specify version
+```
+
+Then execute:
+
+```bash
+docker-compose pull
+docker-compose up -d
+```
+
+<Tip>
+You can view all available versions on the [GitHub Releases](https://github.com/teableio/teable/releases) page.
+</Tip>
+
+## Kubernetes Upgrade
+
+If you deployed Teable using Kubernetes, follow these steps to upgrade:
+
+### Upgrade with Helm
+
+```bash
+# Update Helm repository
+helm repo update
+
+# View available versions
+helm search repo teable --versions
+
+# Upgrade to latest version
+helm upgrade teable teable/teable -n teable
+
+# Or upgrade to specific version
+helm upgrade teable teable/teable -n teable --version x.x.x
+```
+
+### Manual Image Update
+
+If you're using custom Kubernetes configuration, you can directly update the image version in your Deployment:
+
+```bash
+kubectl set image deployment/teable teable=ghcr.io/teableio/teable-ee:0.5.0-alpha-1.x.x-build.xxx -n teable
+```
+
+### Verify Upgrade
+
+```bash
+# Check Pod status
+kubectl get pods -n teable
+
+# Check rollout status
+kubectl rollout status deployment/teable -n teable
+
+# View logs
+kubectl logs -f deployment/teable -n teable
+```
+
+## Database Migration
+
+Teable automatically executes database migrations on startup, no manual intervention required. If you encounter issues after upgrading, check the logs to confirm migration was successful:
+
+```bash
+# Docker Compose
+docker-compose logs teable | grep -i migration
+
+# Kubernetes
+kubectl logs deployment/teable -n teable | grep -i migration
+```
+
+## Rollback
+
+If you encounter issues after upgrading, you can rollback to the previous version.
+
+### Docker Compose Rollback
+
+1. Modify the image tag in `docker-compose.yaml` to the previous version
+2. Execute `docker-compose up -d`
+
+### Kubernetes Rollback
+
+```bash
+# View rollout history
+kubectl rollout history deployment/teable -n teable
+
+# Rollback to previous version
+kubectl rollout undo deployment/teable -n teable
+
+# Rollback to specific revision
+kubectl rollout undo deployment/teable -n teable --to-revision=<revision>
+```
+
+## FAQ
+
+<Accordion title="Will I lose data after upgrading?">
+No. Your data is stored in Docker volumes or external databases, and upgrading containers will not affect your data. However, we still recommend backing up before upgrading.
+</Accordion>
+
+<Accordion title="Will my Instance ID change after upgrading?">
+No. Your Instance ID remains unchanged during application updates. It is a permanent identifier for your self-hosted installation.
+</Accordion>
+
+<Accordion title="How long does the upgrade take?">
+Typically, pulling new images takes a few minutes (depending on network speed), and container restart only takes a few seconds. The entire process usually completes within 5-10 minutes.
+</Accordion>
+
+<Accordion title="Will there be service interruption during upgrade?">
+Using `docker-compose up -d` or Kubernetes rolling update, there will be a brief service interruption (usually a few seconds to tens of seconds). For zero-downtime upgrades, we recommend using Kubernetes with appropriate rolling update strategies configured.
+</Accordion>
+
+<Accordion title="How do I check the current running version?">
+You can check the current version by:
+- Viewing the version number at the bottom left of the Teable interface
+- Using an admin account to access the admin panel
+- Running `docker inspect teable-teable-1 --format='{{.Config.Image}}'` to check the image version
+</Accordion>
+
+<Accordion title="What if the upgrade fails?">
+1. First check container logs to troubleshoot: `docker-compose logs teable`
+2. If it's a database migration issue, try restoring from backup
+3. If the issue persists, rollback to the previous version
+4. Contact support at support@teable.ai
+</Accordion>
+

--- a/zh/deploy/upgrade.mdx
+++ b/zh/deploy/upgrade.mdx
@@ -1,0 +1,198 @@
+---
+title: "版本更新"
+---
+
+本文档介绍如何更新您的 Teable 私有化部署版本。
+
+## 更新频率
+
+Teable 私有化版本的更新完全由您自主决定。只要有新版本发布，您就可以灵活选择是否更新。您可以在 [GitHub Packages](https://github.com/teableio/teable-enterprise/pkgs/container/teable-ee) 查看所有可用版本。
+
+<Tip>
+如果您需要确保稳定性，建议只更新带有 `stable` 标签的版本。
+</Tip>
+
+<Note>
+在进行任何更新操作之前，强烈建议先备份您的数据。
+</Note>
+
+## Docker Compose 更新
+
+如果您使用 Docker Compose 部署 Teable，请按以下步骤更新：
+
+### 1. 备份数据（推荐）
+
+在更新之前，建议先备份重要数据：
+
+**备份 PostgreSQL 数据库：**
+
+```bash
+docker exec teable-db pg_dump -U teable teable > backup_$(date +%Y%m%d).sql
+```
+
+**备份附件数据：**
+
+```bash
+docker run --rm -v teable-data:/data -v $(pwd):/backup alpine tar czf /backup/teable-data_$(date +%Y%m%d).tar.gz /data
+```
+
+### 2. 进入部署目录
+
+```bash
+cd teable  # 进入您的 teable 部署目录
+```
+
+### 3. 拉取最新镜像
+
+```bash
+docker-compose pull
+```
+
+### 4. 重启服务
+
+```bash
+docker-compose up -d
+```
+
+系统会自动使用最新的镜像重新创建容器。您的数据保存在 Docker 卷中，不会丢失。
+
+### 5. 验证更新
+
+```bash
+# 查看容器状态
+docker-compose ps
+
+# 查看日志确认启动正常
+docker-compose logs -f teable
+```
+
+访问您的 Teable 实例，确认服务正常运行。
+
+## 更新到指定版本
+
+如果您希望更新到特定版本而不是最新版本，可以修改 `docker-compose.yaml` 中的镜像标签：
+
+```yaml
+services:
+  teable:
+    image: registry.cn-shenzhen.aliyuncs.com/teable/teable:0.5.0-alpha-1.x.x-build.xxx  # 指定版本号
+```
+
+然后执行：
+
+```bash
+docker-compose pull
+docker-compose up -d
+```
+
+<Tip>
+您可以在 [GitHub Releases](https://github.com/teableio/teable/releases) 页面查看所有可用版本。
+</Tip>
+
+## Kubernetes 更新
+
+如果您使用 Kubernetes 部署 Teable，请按以下步骤更新：
+
+### 使用 Helm 更新
+
+```bash
+# 更新 Helm 仓库
+helm repo update
+
+# 查看可用版本
+helm search repo teable --versions
+
+# 更新到最新版本
+helm upgrade teable teable/teable -n teable
+
+# 或更新到指定版本
+helm upgrade teable teable/teable -n teable --version x.x.x
+```
+
+### 手动更新镜像
+
+如果您使用自定义的 Kubernetes 配置，可以直接更新 Deployment 中的镜像版本：
+
+```bash
+kubectl set image deployment/teable teable=registry.cn-shenzhen.aliyuncs.com/teable/teable:0.5.0-alpha-1.x.x-build.xxx -n teable
+```
+
+### 验证更新
+
+```bash
+# 查看 Pod 状态
+kubectl get pods -n teable
+
+# 查看滚动更新状态
+kubectl rollout status deployment/teable -n teable
+
+# 查看日志
+kubectl logs -f deployment/teable -n teable
+```
+
+## 数据库迁移
+
+Teable 在启动时会自动执行数据库迁移，无需手动干预。如果您在更新后遇到问题，可以查看日志确认迁移是否成功：
+
+```bash
+# Docker Compose
+docker-compose logs teable | grep -i migration
+
+# Kubernetes
+kubectl logs deployment/teable -n teable | grep -i migration
+```
+
+## 回滚版本
+
+如果更新后遇到问题，您可以回滚到之前的版本。
+
+### Docker Compose 回滚
+
+1. 修改 `docker-compose.yaml` 中的镜像标签为之前的版本
+2. 执行 `docker-compose up -d`
+
+### Kubernetes 回滚
+
+```bash
+# 查看历史版本
+kubectl rollout history deployment/teable -n teable
+
+# 回滚到上一个版本
+kubectl rollout undo deployment/teable -n teable
+
+# 回滚到指定版本
+kubectl rollout undo deployment/teable -n teable --to-revision=<revision>
+```
+
+## 常见问题
+
+<Accordion title="更新后数据会丢失吗？">
+不会。您的数据存储在 Docker 卷或外部数据库中，更新容器不会影响数据。但仍建议在更新前进行备份。
+</Accordion>
+
+<Accordion title="实例 ID 会随着更新而变化吗？">
+不会。您的实例 ID 在应用更新过程中保持不变，它是您自托管安装的永久标识符。
+</Accordion>
+
+<Accordion title="更新需要多长时间？">
+通常情况下，拉取新镜像需要几分钟（取决于网络速度），容器重启只需要几秒钟。整个过程通常在 5-10 分钟内完成。
+</Accordion>
+
+<Accordion title="更新时服务会中断吗？">
+使用 `docker-compose up -d` 或 Kubernetes 滚动更新时，会有短暂的服务中断（通常几秒到几十秒）。如果需要零停机更新，建议使用 Kubernetes 并配置适当的滚动更新策略。
+</Accordion>
+
+<Accordion title="如何查看当前运行的版本？">
+您可以通过以下方式查看当前版本：
+- 在 Teable 界面左下角查看版本号
+- 使用管理员账号进入管理面板查看
+- 执行 `docker inspect teable-teable-1 --format='{{.Config.Image}}'` 查看镜像版本
+</Accordion>
+
+<Accordion title="更新失败怎么办？">
+1. 首先查看容器日志排查问题：`docker-compose logs teable`
+2. 如果是数据库迁移问题，尝试从备份恢复数据
+3. 如果问题持续，可以回滚到之前的版本
+4. 联系支持团队 support@teable.ai
+</Accordion>
+


### PR DESCRIPTION
Add comprehensive upgrade documentation for Docker Compose and Kubernetes deployments.

- Update frequency explanation with link to GitHub Packages
- Step-by-step upgrade instructions with backup recommendations
- Support for specific version upgrades
- Database migration notes
- Rollback procedures
- FAQ section covering common upgrade questions