### PR TITLE
docs: simplify backup section in upgrade guide

### DIFF
--- a/en/deploy/upgrade.mdx
+++ b/en/deploy/upgrade.mdx
@@ -20,26 +20,6 @@ If you deployed Teable using Docker Compose, follow these steps to upgrade:
 
 We recommend backing up your entire cloud server, or backing up the PostgreSQL / Redis / storage volumes you're using.
 
-If you need fine-grained logical backups:
-
-**Backup PostgreSQL database (table data):**
-
-```bash
-docker exec teable-db pg_dump -U teable teable > backup_$(date +%Y%m%d).sql
-```
-
-**Backup attachment data (user uploaded files):**
-
-```bash
-docker run --rm -v teable-data:/data -v $(pwd):/backup alpine tar czf /backup/teable-data_$(date +%Y%m%d).tar.gz /data
-```
-
-**Backup Redis data (Automation queue data):**
-
-```bash
-docker exec teable-cache redis-cli BGSAVE
-```
-
 ### Navigate to Deployment Directory
 
 ```bash
@@ -199,4 +179,3 @@ You can check the current version by:
 3. If the issue persists, rollback to the previous version
 4. Contact support at support@teable.ai
 </Accordion>
-

--- a/zh/deploy/upgrade.mdx
+++ b/zh/deploy/upgrade.mdx
@@ -20,26 +20,6 @@ Teable 私有化版本的更新完全由您自主决定。只要有新版本发�
 
 我们建议直接备份整个云主机，或者备份使用到的 PostgreSQL / Redis / 存储卷。
 
-如果需要进行精细的逻辑备份：
-
-**备份 PostgreSQL 数据库（表格数据）：**
-
-```bash
-docker exec teable-db pg_dump -U teable teable > backup_$(date +%Y%m%d).sql
-```
-
-**备份附件数据（用户上传的附件数据）：**
-
-```bash
-docker run --rm -v teable-data:/data -v $(pwd):/backup alpine tar czf /backup/teable-data_$(date +%Y%m%d).tar.gz /data
-```
-
-**备份 Redis 数据（Automation 队列数据）：**
-
-```bash
-docker exec teable-cache redis-cli BGSAVE
-```
-
 ### 进入部署目录
 
 ```bash
@@ -199,4 +179,3 @@ kubectl rollout undo deployment/teable -n teable --to-revision=<revision>
 3. 如果问题持续，可以回滚到之前的版本
 4. 联系支持团队 support@teable.ai
 </Accordion>
-


### PR DESCRIPTION
- Recommend backing up entire cloud server or volumes
- Remove detailed logical backup commands
- Remove stable tag tip (not currently applicable)