### PR TITLE
docs: add Data Backup & Export section to security page

### DIFF
--- a/en/basic/security.mdx
+++ b/en/basic/security.mdx
@@ -106,6 +106,21 @@ Track all changes made to your records with a comprehensive revision history:
 
 Deleted items are moved to trash and can be recovered within the retention period, providing protection against accidental data loss.
 
+### Data Backup & Export
+
+Teable provides multiple options for backing up your data:
+
+| Method | Description | Use Case |
+|--------|-------------|----------|
+| **[Base Export](/en/basic/base/base#export-database)** | Download entire Base as `.tea` file (structure, data, automations) | Full backup, migration |
+| **[Base Duplicate](/en/basic/base/base#duplicate-a-base-to-another-space)** | Create a copy of Base within Teable | Quick snapshot |
+| **[CSV Export](/en/basic/table/export)** | Export individual table data | Data portability |
+| **[API Export](/en/api-doc/record/get)** | Programmatically export records via REST API | Automated backups |
+
+<Tip>
+You can manually back up your bases by exporting the entire Base as a `.tea` file, exporting individual tables as CSV files, or retrieving your data via the Teable API.
+</Tip>
+
 ## Single Sign-On (SSO)
 
 Teable supports enterprise SSO through the **OIDC (OpenID Connect)** protocol, compatible with major identity providers:

--- a/zh/basic/security.mdx
+++ b/zh/basic/security.mdx
@@ -106,6 +106,21 @@ Teable 提供细粒度的基于角色的访问控制，包含五个权限级别�
 
 删除的项目会移至回收站，可以在保留期内恢复，防止意外数据丢失。
 
+### 数据备份与导出
+
+Teable 提供多种数据备份方式：
+
+| 方式 | 说明 | 适用场景 |
+|------|------|----------|
+| **[Base 导出](/zh/basic/base/base#export-database)** | 将整个 Base 下载为 `.tea` 文件（包含结构、数据、自动化） | 完整备份、迁移 |
+| **[Base 复制](/zh/basic/base/base#duplicate-a-base-to-another-space)** | 在 Teable 内创建 Base 副本 | 快速快照 |
+| **[CSV 导出](/zh/basic/table/export)** | 导出单个表格数据 | 数据迁移 |
+| **[API 导出](/zh/api-doc/record/get)** | 通过 REST API 程序化导出记录 | 自动化备份 |
+
+<Tip>
+您可以通过导出整个 Base 为 `.tea` 文件、导出单个表格为 CSV 文件，或通过 Teable API 获取数据来手动备份您的数据库。
+</Tip>
+
 ## 单点登录 (SSO)
 
 Teable 通过 **OIDC（OpenID Connect）** 协议支持企业 SSO，兼容主要身份提供商：


### PR DESCRIPTION
## Summary

Add a new "Data Backup & Export" section to the Security page (both EN and ZH versions) to help users understand their backup options.

## Changes

- Added a table listing 4 backup methods with descriptions and use cases:
  - **Base Export** - Download entire Base as `.tea` file
  - **Base Duplicate** - Create a copy of Base within Teable
  - **CSV Export** - Export individual table data
  - **API Export** - Programmatically export records via REST API

- Each method includes a link to its documentation
- Added a tip summarizing manual backup options (similar to Airtable's style)

## Why

Users frequently ask about data backup options for security concerns. This section provides clear guidance on available self-service backup methods.