### PR TITLE
fix: hide plugin and dashboard documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -171,13 +171,6 @@
                     ]
                   },
                   {
-                    "group": "Plugin",
-                    "pages": [
-                      "en/basic/plugin/chart",
-                      "en/basic/plugin/sheet-form"
-                    ]
-                  },
-                  {
                     "group": "Authority Matrix",
                     "pages": [
                       "en/basic/authority-matrix/authority-matrix",
@@ -448,13 +441,6 @@
                       "zh/basic/view/kanban",
                       "zh/basic/view/gallery",
                       "zh/basic/view/calendar"
-                    ]
-                  },
-                  {
-                    "group": "插件",
-                    "pages": [
-                      "zh/basic/plugin/chart",
-                      "zh/basic/plugin/sheet-form"
                     ]
                   },
                   {

--- a/en/sdk.mdx
+++ b/en/sdk.mdx
@@ -1,3 +1,0 @@
-# Plugin SDK
-
-<Info>Coming soon</Info>

--- a/zh/sdk.mdx
+++ b/zh/sdk.mdx
@@ -1,3 +1,0 @@
-# Plugin SDK
-
-<Info>即将推出</Info>


### PR DESCRIPTION
## Summary

This PR hides the Plugin and Dashboard related content from the documentation navigation and SEO indexing.

## Changes

### docs.json
- Removed the "Plugin" navigation group from the English documentation (including chart and sheet-form pages)
- Removed the "插件" (Plugin) navigation group from the Chinese documentation (including chart and sheet-form pages)

### swagger.json
- Removed 11 dashboard-related API endpoints from the API reference:
  - `/base/{baseId}/dashboard`
  - `/base/{baseId}/dashboard/{id}`
  - `/base/{baseId}/dashboard/{dashboardId}/rename`
  - `/base/{baseId}/dashboard/{id}/layout`
  - `/base/{baseId}/dashboard/{id}/plugin`
  - `/base/{baseId}/dashboard/{dashboardId}/plugin/{pluginInstallId}`
  - `/base/{baseId}/dashboard/{dashboardId}/plugin/{pluginInstallId}/rename`
  - `/base/{baseId}/dashboard/{dashboardId}/plugin/{pluginInstallId}/update-storage`
  - `/base/{baseId}/dashboard/{id}/duplicate`
  - `/base/{baseId}/dashboard/{id}/plugin/{installedId}/duplicate`
  - `/plugin/chart/{pluginInstallId}/dashboard/{positionId}/query`

## Result
- Plugin documentation will no longer appear in the sidebar navigation
- Dashboard API endpoints will no longer appear in API documentation search results
- Both will be excluded from SEO indexing