### PR TITLE
docs: update App Builder video link in changelog

### DIFF
--- a/en/changelog.mdx
+++ b/en/changelog.mdx
@@ -7,7 +7,7 @@ title: "Changelog"
 
 We’ve rebuilt the App Builder engine to significantly improve stability, accuracy, and build performance. Here’s what’s new:
 
-<video controls className="w-full aspect-video" src="https://dxshyegpql0u3hra.public.blob.vercel-storage.com/2ee243fcdd676bd8d1daa098c4515ba9.mp4" />
+<video controls className="w-full aspect-video" src="https://dxshyegpql0u3hra.public.blob.vercel-storage.com/072120054c6e83a690f319e1a130dda1.mp4" />
 
 > **Note:** This update applies only to apps created after December 17, 2025. Older apps should be recreated to benefit from the improvements.
 


### PR DESCRIPTION
Update the App Builder demo video link in the changelog for v1.11.0