### PR TITLE
fix: add missing uploadDate to video schema for SEO

### DIFF
--- a/en/changelog.mdx
+++ b/en/changelog.mdx
@@ -58,6 +58,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 1. **Talk to Build Databases:** Say goodbye to disorganized leads. Teable can automatically tag sentiment and draft replies from your CRM data.
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Talk to Build Databases",
+  "description": "Teable can automatically tag sentiment and draft replies from your CRM data.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/case1+talk+to+build+databases_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -66,6 +75,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 2. **Talk to Build Apps on Data:** Generate apps directly from your database (e.g., turn a leads table into a landing page in minutes). Unlike vibe-coding tools that leave you with a dead app, Teable builds apps that actually run on live data
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Talk to Build Apps on Data",
+  "description": "Generate apps directly from your database.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case2+Talk+to+build+apps+on+data_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -74,6 +92,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 3. **Talk to Automate Workflow:** Create automations in plain language (e.g., “email your customer or teammate when a form is submitted”). Customers and teammates get notified instantly.
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Talk to Automate Workflow",
+  "description": "Create automations in plain language.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case3+Talk+to+automate+workflow_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -82,6 +109,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 4. **Talk to Data for Analysis:** Conversational query, visualize, and get instant insights on your data. No SQL, no code.
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Talk to Data for Analysis",
+  "description": "Conversational query, visualize, and get instant insights on your data.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case4+Talk+to+data+for+analysis_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -90,6 +126,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 5. **Talk to Process Data at Scale:** Batch-handle files and auto-extract key fields.  (e.g., just drop in your invoices, then hit the share button and send it straight to your accountant)
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Talk to Process Data at Scale",
+  "description": "Batch-handle files and auto-extract key fields.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/case5+talk+to+process+files_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -98,6 +143,15 @@ This release brings **6 big revolutions**, rewriting how we work with data.
 
 6. **Batch Image & Copy Generation:** Batch-generate product images, copy, and video scripts to become a super marketer
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Batch Image & Copy Generation",
+  "description": "Batch-generate product images, copy, and video scripts.",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case6+Batch+image+&+copy+generation_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"

--- a/zh/changelog.mdx
+++ b/zh/changelog.mdx
@@ -58,6 +58,15 @@ title: "更新日志"
 AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 1. 对话生成数据库：再也不用为线索混乱发愁，Teable能自动识别情感、帮你写好CRM回复。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "对话生成数据库",
+  "description": "Teable能自动识别情感、帮你写好CRM回复。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/case1+talk+to+build+databases_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -66,6 +75,15 @@ AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 
 2. 对话生成应用：直接用数据库里的数据生成应用，比如几分钟就能把线索表变成落地页。和那些只能做静态应用的工具不同，Teable做出来的应用是真正跑在实时数据上的。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "对话生成应用",
+  "description": "直接用数据库里的数据生成应用，应用真正跑在实时数据上。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case2+Talk+to+build+apps+on+data_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -74,6 +92,15 @@ AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 
 3. 对话自动化流程：用自然语言就能搭建自动化，比如“表单提交后自动发邮件给客户或同事”，消息秒发到位。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "对话自动化流程",
+  "description": "用自然语言就能搭建自动化，消息秒发到位。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case3+Talk+to+automate+workflow_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -82,6 +109,15 @@ AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 
 4. 对话分析数据：直接问问题、看图表，数据洞察一秒到手，无需SQL、无需写代码。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "对话分析数据",
+  "description": "直接问问题、看图表，数据洞察一秒到手。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case4+Talk+to+data+for+analysis_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -90,6 +126,15 @@ AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 
 5. 批量处理文件：批量上传文件，自动提取关键信息，比如发票一拖就能自动识别，点分享直接发给会计。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "批量处理文件",
+  "description": "批量上传文件，自动提取关键信息。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/case5+talk+to+process+files_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"
@@ -98,6 +143,15 @@ AI数据库Agent带来6大创新，彻底改变你用数据的方式：
 
 6. 批量生成图片和文案：一键批量生成商品图片、文案、视频脚本，营销效率翻倍。
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "批量生成图片和文案",
+  "description": "一键批量生成商品图片、文案、视频脚本，营销效率翻倍。",
+  "thumbnailUrl": ["https://teable.ai/assets/images/og-image.png"],
+  "uploadDate": "2025-09-16T00:00:00+08:00",
+  "contentUrl": "https://teable-media.s3.us-west-2.amazonaws.com/video/Case6+Batch+image+&+copy+generation_compressed.mp4"
+}) }} />
 <video
   controls
   className="w-full aspect-video"


### PR DESCRIPTION
This PR adds explicit VideoObject schema with uploadDate to videos in changelog to resolve Google Search Console warnings.