### PR TITLE
fix: rename Architecture to Engine

### DIFF
--- a/en/changelog.mdx
+++ b/en/changelog.mdx
@@ -23,7 +23,7 @@ In **App Builder**, click **Publish** in the top right. Enter your custom domain
 <video controls className="w-full aspect-video" src="https://dxshyegpql0u3hra.public.blob.vercel-storage.com/7e2df155d66ef236a6adf7675a3dd908.mp4" />
 
 <AccordionGroup>
-<Accordion title="New Agent Architecture — Coming Soon (11)">
+<Accordion title="New Agent Engine — Coming Soon (11)">
 - Significantly reduced AI credit usage. In our test cases, efficiency improved by 5x–20x.
 - Significantly improved complex task capability. For example, in AI Chat you can provide an Airtable API key and migrate a Base directly.
 - Improved large-file processing in AI Chat, including handling more than a dozen Excel/CSV files or a 100-page PDF in one run.
@@ -37,7 +37,7 @@ In **App Builder**, click **Publish** in the top right. Enter your custom domain
 - Billing now provides more detailed credit usage visibility.
 </Accordion>
 
-<Accordion title="New App Builder Architecture — Coming Soon (4)">
+<Accordion title="New App Builder Engine — Coming Soon (4)">
 - Fixed App Builder preview issues for a smoother building experience.
 - Added environment variable configuration to support third-party integrations, significantly expanding App Builder use cases.
 - Enhanced overall stability with a significantly improved building experience.


### PR DESCRIPTION
## Summary
- Renamed "New Agent Architecture" to "New Agent Engine" in the English changelog
- Renamed "New App Builder Architecture" to "New App Builder Engine" in the English changelog