### PR TITLE
[codex] Restore custom model compatibility notice and note styling

### DIFF
--- a/en/basic/ai/custom-model.mdx
+++ b/en/basic/ai/custom-model.mdx
@@ -1,11 +1,23 @@
 ---
 title: Custom AI Model
-description: Enable AI capabilities in a space and add model providers for AI Fields, AI automation, and AI Chat.
+description: Enable AI capabilities in a space and add model providers for AI Fields, Automations, AI Chat, and App Builder.
 ---
 
 <Tip>Available for Pro plan and above</Tip>
 
-Custom model configuration applies to space-level AI features. After setup, the models you add can be used by **AI Fields**, **AI automation**, and **AI Chat**.
+<Note>
+Custom model configuration applies to all Teable AI features, including **AI Chat**, **AI Fields**, **App Builder**, and **Automations**.
+
+Starting April 9, 2026, Teable's agent engine has been upgraded to enhance AI capabilities across **AI Chat Agent** mode and **App Builder**. As part of this upgrade, these features currently only support Anthropic-compatible API endpoints. **Using incompatible endpoints may result in errors.**
+
+- **Cloud users with BYOK:** If your custom model provider does not support the Anthropic Messages API format, AI Chat Agent and App Builder will not function with your BYOK configuration. Please switch to an Anthropic-compatible provider (e.g. Anthropic API, OpenRouter) or use the default Teable model.
+- **Self-hosted users:** Please ensure your configured LLM endpoint is Anthropic-compatible. Alternatively, you can wait for our upcoming OpenAI-compatible endpoint support and pull the latest image once it's available.
+- **OpenAI-compatible endpoint support** is on our roadmap and will be added in a future release.
+
+**We recommend using Teable Credits.** Teable Credits are currently offered at cost — no middleman, no markup — giving you access to top-tier AI models at the most competitive pricing with the smoothest experience.
+</Note>
+
+After setup, the models you add can be used by **AI Fields**, **Automations**, **AI Chat**, and **App Builder** in the current space.
 
 ## Where to Configure It
 

--- a/style.css
+++ b/style.css
@@ -86,6 +86,42 @@ html:not(.dark) #banner a {
   border-color: rgba(255, 255, 255, 0.25);
 }
 
+/* Restore blue informational callouts */
+.callout[data-callout-type="note"] {
+  border-color: rgba(96, 165, 250, 0.45) !important;
+  background: rgba(239, 246, 255, 0.9) !important;
+}
+
+.callout[data-callout-type="note"] [data-component-part="callout-icon"] svg {
+  color: rgb(59, 130, 246) !important;
+}
+
+.callout[data-callout-type="note"] [data-component-part="callout-content"] {
+  color: rgb(30, 64, 175) !important;
+}
+
+.callout[data-callout-type="note"] [data-component-part="callout-content"] strong,
+.callout[data-callout-type="note"] [data-component-part="callout-content"] a,
+.callout[data-callout-type="note"] [data-component-part="callout-content"] code,
+.callout[data-callout-type="note"] [data-component-part="callout-content"] p,
+.callout[data-callout-type="note"] [data-component-part="callout-content"] li,
+.callout[data-callout-type="note"] [data-component-part="callout-content"] span {
+  color: inherit !important;
+}
+
+.dark .callout[data-callout-type="note"] {
+  border-color: rgba(96, 165, 250, 0.35) !important;
+  background: rgba(30, 58, 138, 0.22) !important;
+}
+
+.dark .callout[data-callout-type="note"] [data-component-part="callout-icon"] svg {
+  color: rgb(147, 197, 253) !important;
+}
+
+.dark .callout[data-callout-type="note"] [data-component-part="callout-content"] {
+  color: rgb(219, 234, 254) !important;
+}
+
 /* Move language selector to bottom-right on desktop only */
 @media (min-width: 1024px) {
   #localization-select-trigger {

--- a/zh/basic/ai/custom-model.mdx
+++ b/zh/basic/ai/custom-model.mdx
@@ -1,11 +1,23 @@
 ---
 title: 自定义 AI 模型
-description: 在空间中开启 AI 能力并添加模型提供商，用于 AI 字段、AI 自动化和 AI 聊天。
+description: 在空间中开启 AI 能力并添加模型提供商，用于 AI 字段、自动化、AI Chat 和 App Builder。
 ---
 
 <Tip>Pro 版及以上适用</Tip>
 
-自定义模型配置适用于空间级 AI 功能。配置完成后，添加的模型可以供 **AI 字段**、**AI 自动化** 和 **AI 聊天** 使用。
+<Note>
+自定义模型配置适用于所有 Teable AI 功能，包括 **AI Chat**、**AI 字段**、**App Builder** 和**自动化**。
+
+自 2026 年 4 月 9 日起，Teable 的 Agent 引擎已完成升级，以提升 **AI Chat Agent** 模式和 **App Builder** 的 AI 能力。本次升级后，这些功能当前仅支持 Anthropic 兼容的 API 端点，**使用不兼容的端点可能会导致报错。**
+
+- **Cloud 用户（BYOK）：** 如果您的自定义模型提供商不支持 Anthropic Messages API 格式，AI Chat Agent 和 App Builder 将无法使用您的 BYOK 配置。请切换至 Anthropic 兼容的提供商（如 Anthropic API、OpenRouter），或使用 Teable 默认模型。
+- **私有化部署用户：** 请确保您配置的 LLM 端点兼容 Anthropic 格式。您也可以等待我们后续适配 OpenAI 兼容端点后，拉取最新镜像即可。
+- **OpenAI 兼容端点支持**已在规划中，将在后续版本中推出。
+
+**推荐使用 Teable Credits：** Teable Credits 当前以成本价提供，没有中间商赚差价，让您以最优惠的价格使用顶级 AI 模型，体验最流畅。
+</Note>
+
+配置完成后，添加的模型可以供当前空间内的 **AI 字段**、**自动化**、**AI Chat** 和 **App Builder** 使用。
 
 ## 配置入口
 


### PR DESCRIPTION
## What changed

This PR restores the compatibility notice at the top of the Custom AI Model page in both Chinese and English.

It also restores the visual treatment of `Note` callouts so this notice reads as a blue informational block again, matching the earlier presentation instead of inheriting the newer monochrome text treatment.

## Why it changed

The compatibility notice is important and needs to be visible immediately when users open the page.

The current site theme moved the primary color system to a monochrome palette, so `Note` callouts no longer looked like informational guidance. The result was that the restored notice appeared in black text, which was less recognizable and less consistent with the earlier design.

## style.css change

The `style.css` update is intentionally narrow:

- It targets only `.callout[data-callout-type="note"]`.
- It restores a blue border, blue-tinted background, blue icon color, and blue text color for `Note` callouts.
- It preserves inheritance for strong text, links, code, paragraphs, list items, and spans inside the callout so the full notice stays visually consistent.
- It includes a dark-mode variant so the note remains readable without changing the broader monochrome site styling.

This does **not** change the overall site theme, banner styling, or other callout types such as `Tip`.

## Impact

- Users now see the Anthropic compatibility notice immediately in both languages.
- The notice looks like an informational callout again instead of blending into the monochrome page styling.
- Other parts of the site keep their current appearance.

## Validation

- `git diff --check`
- Verified `http://localhost:3000/zh/basic/ai/custom-model`
- Verified `http://localhost:3000/en/basic/ai/custom-model`
