### PR TITLE
chore: notify Teable on Mintlify deploy

### DIFF
--- a/.github/workflows/notify-teable-on-mintlify-deploy.yml
+++ b/.github/workflows/notify-teable-on-mintlify-deploy.yml
@@ -61,13 +61,14 @@ jobs:
 
       - name: Notify Teable webhook
         env:
+          TEABLE_WEBHOOK_URL: ${{ secrets.TEABLE_WEBHOOK_URL }}
           TEABLE_WEBHOOK_TOKEN: ${{ secrets.TEABLE_WEBHOOK_TOKEN }}
           DOCS_BRANCH: ${{ github.event.pull_request.head.ref }}
           DOCS_URL: ${{ steps.wait.outputs.docs_url }}
         run: |
           set -euo pipefail
           curl -fsS -X POST \
-            "https://app.teable.ai/api/webhook/base/bseu12nLHShtmzYAUYv/workflow/wflM8nejDTw9ZHob2bv" \
+            "$TEABLE_WEBHOOK_URL" \
             -H "Authorization: Bearer $TEABLE_WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$(jq -nc --arg b "$DOCS_BRANCH" --arg u "$DOCS_URL" '{docs_branch:$b, docs_url:$u}')"

--- a/.github/workflows/notify-teable-on-mintlify-deploy.yml
+++ b/.github/workflows/notify-teable-on-mintlify-deploy.yml
@@ -1,0 +1,73 @@
+name: Notify Teable on Mintlify Deploy
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  deployments: read
+  pull-requests: read
+  contents: read
+
+jobs:
+  notify-teable:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Wait for Mintlify deployment
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          echo "Waiting for Mintlify staging deployment of $SHA"
+          DEADLINE=$(( $(date +%s) + 720 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            DEPS=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/deployments?sha=$SHA&environment=staging&per_page=20")
+            DID=$(echo "$DEPS" | python3 -c "
+          import json,sys
+          for d in json.load(sys.stdin):
+            if d.get('creator',{}).get('login') == 'mintlify[bot]':
+              print(d['id']); break
+          ")
+            if [ -n "$DID" ]; then
+              STATE=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/$REPO/deployments/$DID/statuses?per_page=1" \
+                | python3 -c "import json,sys;ss=json.load(sys.stdin);print(ss[0]['state'] if ss else '')")
+              echo "deployment=$DID state=$STATE"
+              case "$STATE" in
+                success)
+                  ENV_URL=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/repos/$REPO/deployments/$DID/statuses?per_page=1" \
+                    | python3 -c "import json,sys;ss=json.load(sys.stdin);print(ss[0].get('environment_url') or ss[0].get('target_url') or '')")
+                  echo "docs_url=$ENV_URL" >> "$GITHUB_OUTPUT"
+                  exit 0
+                  ;;
+                failure|error)
+                  echo "Mintlify deployment $DID failed: $STATE" >&2
+                  exit 1
+                  ;;
+              esac
+            fi
+            sleep 15
+          done
+          echo "Timed out waiting for Mintlify deployment of $SHA" >&2
+          exit 1
+
+      - name: Notify Teable webhook
+        env:
+          TEABLE_WEBHOOK_TOKEN: ${{ secrets.TEABLE_WEBHOOK_TOKEN }}
+          DOCS_BRANCH: ${{ github.event.pull_request.head.ref }}
+          DOCS_URL: ${{ steps.wait.outputs.docs_url }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST \
+            "https://app.teable.ai/api/webhook/base/bseu12nLHShtmzYAUYv/workflow/wflM8nejDTw9ZHob2bv" \
+            -H "Authorization: Bearer $TEABLE_WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg b "$DOCS_BRANCH" --arg u "$DOCS_URL" '{docs_branch:$b, docs_url:$u}')"


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that fires when a PR is merged into `main`, waits for Mintlify's staging deployment to reach `success`, then POSTs the docs branch name to a Teable webhook. Teable then updates the matching `Docs Sync Runs` record (Status → `launch`) and sends a Feishu notification.

## How it works
1. Triggered by `pull_request: closed` on `main` (only runs if `merged == true`).
2. Polls GitHub Deployments API for a deployment matching the merge SHA, environment `staging`, creator `mintlify[bot]`.
3. On `success` → POST `{docs_branch, docs_url}` to the Teable webhook.
4. Fails on `failure`/`error` or after 12 minutes timeout.

## Requires
Repo secret `TEABLE_WEBHOOK_TOKEN` (configured separately).

## Why a new workflow
`pages-build-deployment` is GitHub-managed (legacy Pages) — not a workflow file. Mintlify's deployment is created by the Mintlify GitHub App. Neither is editable. This is a single-file, single-purpose workflow that does not touch any existing deploy path.
