### PR TITLE
docs: document session origin check env T3806

### DIFF
--- a/en/deploy/env.mdx
+++ b/en/deploy/env.mdx
@@ -66,6 +66,7 @@ Also ensure the public bucket is configured with **public-read + CORS**. See: [O
 | Session/JWT Configuration                                                                                               |
 | BACKEND_SESSION_EXPIRES_IN                 | Session expiration time                                                   | 7d              | -        | 7d                                                |
 | BACKEND_SESSION_COOKIE_SECURE              | Whether to secure session cookie                                         | false           | -        | true                                              |
+| BACKEND_SESSION_ORIGIN_CHECK_ENABLED       | Enable Origin and Fetch Metadata checks for unsafe browser session-cookie API requests. Enable only when your proxy or CDN preserves these request headers | false           | -        | true                                              |
 | BACKEND_JWT_EXPIRES_IN                     | JWT expiration time                                                       | 20d             | -        | 20d                                               |
 | BACKEND_RESET_PASSWORD_EMAIL_EXPIRES_IN    | Reset password email expiration time                                      | 30m             | -        | 30m                                               |
 | Resource Limits                                                                                                         |

--- a/zh/deploy/env.mdx
+++ b/zh/deploy/env.mdx
@@ -66,6 +66,7 @@ mode: "wide"
 | 会话/JWT 配置                                                                     |
 | BACKEND_SESSION_EXPIRES_IN                | 会话过期时间                                                  | 7d               | -    | 7d                                               |
 | BACKEND_SESSION_COOKIE_SECURE             | 是否启用会话 Cookie 安全保护，默认为 false                      | false            | -    | true                                             |
+| BACKEND_SESSION_ORIGIN_CHECK_ENABLED      | 是否启用针对浏览器会话 Cookie 写请求的 Origin 和 Fetch Metadata 校验。仅在代理或 CDN 会透传这些请求头时开启 | false            | -    | true                                             |
 | BACKEND_JWT_EXPIRES_IN                    | JWT 过期时间                                                | 20d              | -    | 20d                                              |
 | BACKEND_RESET_PASSWORD_EMAIL_EXPIRES_IN | 重置密码邮件过期时间                                              | 30m              | -    | 30m                                              |
 | 资源限制                                                                          |


### PR DESCRIPTION
## Summary\n- Document BACKEND_SESSION_ORIGIN_CHECK_ENABLED in English and Chinese env docs\n- Clarify that the check should be enabled only when proxies/CDNs preserve Origin and Fetch Metadata headers\n\n## Verification\n- git diff --check