### PR TITLE
chore: report missing Mintlify deployments

### DIFF
--- a/.github/workflows/notify-teable-on-mintlify-deploy.yml
+++ b/.github/workflows/notify-teable-on-mintlify-deploy.yml
@@ -16,6 +16,37 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Detect Mintlify relevance
+        id: relevance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          FILES="[]"
+          PAGE=1
+          while true; do
+            PAGE_FILES=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE")
+            COUNT=$(echo "$PAGE_FILES" | python3 -c "import json,sys;print(len(json.load(sys.stdin)))")
+            FILES=$(jq -s 'add' <(echo "$FILES") <(echo "$PAGE_FILES"))
+            if [ "$COUNT" -lt 100 ]; then
+              break
+            fi
+            PAGE=$((PAGE + 1))
+          done
+          NEEDS_DEPLOY=$(echo "$FILES" | python3 -c "
+          import json,sys
+          paths = [f.get('filename','') for f in json.load(sys.stdin)]
+          prefixes = ('en/', 'zh/', 'images/', 'snippets/', 'api-reference/')
+          exact = {'docs.json', 'mint.json', 'swagger.json', 'style.css', 'changelog-toc.js'}
+          needs = any(p in exact or p.startswith(prefixes) for p in paths)
+          print('true' if needs else 'false')
+          ")
+          echo "needs_mintlify_deploy=$NEEDS_DEPLOY" >> "$GITHUB_OUTPUT"
+          echo "needs_mintlify_deploy=$NEEDS_DEPLOY"
+
       - name: Record GitHub merge
         env:
           TEABLE_WEBHOOK_URL: ${{ secrets.TEABLE_WEBHOOK_URL }}
@@ -40,14 +71,24 @@ jobs:
               --arg t "$MERGED_AT" \
               '{docs_branch:$b, mintlify_status:$s, pr_number:$p, pr_url:$r, merge_sha:$m, merged_at:$t}')"
 
-      - name: Wait for Mintlify deployment
-        id: wait
+      - name: Resolve Mintlify deployment status
+        id: mintlify
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          NEEDS_MINTLIFY_DEPLOY: ${{ steps.relevance.outputs.needs_mintlify_deploy }}
         run: |
           set -euo pipefail
+
+          if [ "$NEEDS_MINTLIFY_DEPLOY" != "true" ]; then
+            echo "Mintlify deployment not required for this PR"
+            echo "docs_url=" >> "$GITHUB_OUTPUT"
+            echo "mintlify_status=not_required" >> "$GITHUB_OUTPUT"
+            echo "mintlify_deployment_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Waiting for Mintlify staging deployment of $SHA"
           DEADLINE=$(( $(date +%s) + 720 ))
           LAST_DEPLOYMENT_ID=""
@@ -106,15 +147,16 @@ jobs:
           TEABLE_WEBHOOK_URL: ${{ secrets.TEABLE_WEBHOOK_URL }}
           TEABLE_WEBHOOK_TOKEN: ${{ secrets.TEABLE_WEBHOOK_TOKEN }}
           DOCS_BRANCH: ${{ github.event.pull_request.head.ref }}
-          DOCS_URL: ${{ steps.wait.outputs.docs_url }}
-          MINTLIFY_STATUS: ${{ steps.wait.outputs.mintlify_status }}
-          MINTLIFY_DEPLOYMENT_ID: ${{ steps.wait.outputs.mintlify_deployment_id }}
+          DOCS_URL: ${{ steps.mintlify.outputs.docs_url }}
+          MINTLIFY_STATUS: ${{ steps.mintlify.outputs.mintlify_status }}
+          MINTLIFY_DEPLOYMENT_ID: ${{ steps.mintlify.outputs.mintlify_deployment_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           MERGED_AT: ${{ github.event.pull_request.merged_at }}
         run: |
           set -euo pipefail
+          STATUS="${MINTLIFY_STATUS:-error}"
           curl -fsS -X POST \
             "$TEABLE_WEBHOOK_URL" \
             -H "Authorization: Bearer $TEABLE_WEBHOOK_TOKEN" \
@@ -122,7 +164,7 @@ jobs:
             -d "$(jq -nc \
               --arg b "$DOCS_BRANCH" \
               --arg u "$DOCS_URL" \
-              --arg s "$MINTLIFY_STATUS" \
+              --arg s "$STATUS" \
               --arg d "$MINTLIFY_DEPLOYMENT_ID" \
               --arg p "$PR_NUMBER" \
               --arg r "$PR_URL" \
@@ -131,7 +173,7 @@ jobs:
               '{docs_branch:$b, docs_url:$u, mintlify_status:$s, mintlify_deployment_id:$d, pr_number:$p, pr_url:$r, merge_sha:$m, merged_at:$t}')"
 
       - name: Fail if Mintlify did not deploy
-        if: steps.wait.outputs.mintlify_status != 'success'
+        if: steps.relevance.outputs.needs_mintlify_deploy == 'true' && steps.mintlify.outputs.mintlify_status != 'success'
         run: |
-          echo "Mintlify did not deploy successfully: ${{ steps.wait.outputs.mintlify_status }}" >&2
+          echo "Mintlify did not deploy successfully: ${{ steps.mintlify.outputs.mintlify_status }}" >&2
           exit 1

--- a/.github/workflows/notify-teable-on-mintlify-deploy.yml
+++ b/.github/workflows/notify-teable-on-mintlify-deploy.yml
@@ -26,6 +26,9 @@ jobs:
           set -euo pipefail
           echo "Waiting for Mintlify staging deployment of $SHA"
           DEADLINE=$(( $(date +%s) + 720 ))
+          LAST_DEPLOYMENT_ID=""
+          LAST_DEPLOYMENT_STATE=""
+
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             DEPS=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/$REPO/deployments?sha=$SHA&environment=staging&per_page=20")
@@ -36,9 +39,11 @@ jobs:
               print(d['id']); break
           ")
             if [ -n "$DID" ]; then
+              LAST_DEPLOYMENT_ID="$DID"
               STATE=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
                 "https://api.github.com/repos/$REPO/deployments/$DID/statuses?per_page=1" \
                 | python3 -c "import json,sys;ss=json.load(sys.stdin);print(ss[0]['state'] if ss else '')")
+              LAST_DEPLOYMENT_STATE="$STATE"
               echo "deployment=$DID state=$STATE"
               case "$STATE" in
                 success)
@@ -46,29 +51,61 @@ jobs:
                     "https://api.github.com/repos/$REPO/deployments/$DID/statuses?per_page=1" \
                     | python3 -c "import json,sys;ss=json.load(sys.stdin);print(ss[0].get('environment_url') or ss[0].get('target_url') or '')")
                   echo "docs_url=$ENV_URL" >> "$GITHUB_OUTPUT"
+                  echo "mintlify_status=success" >> "$GITHUB_OUTPUT"
+                  echo "mintlify_deployment_id=$DID" >> "$GITHUB_OUTPUT"
                   exit 0
                   ;;
                 failure|error)
                   echo "Mintlify deployment $DID failed: $STATE" >&2
-                  exit 1
+                  echo "mintlify_status=$STATE" >> "$GITHUB_OUTPUT"
+                  echo "mintlify_deployment_id=$DID" >> "$GITHUB_OUTPUT"
+                  exit 0
                   ;;
               esac
             fi
             sleep 15
           done
-          echo "Timed out waiting for Mintlify deployment of $SHA" >&2
-          exit 1
+
+          if [ -n "$LAST_DEPLOYMENT_ID" ]; then
+            echo "Timed out waiting for Mintlify deployment $LAST_DEPLOYMENT_ID to succeed; last state: ${LAST_DEPLOYMENT_STATE:-unknown}" >&2
+            echo "mintlify_status=deployment_timeout" >> "$GITHUB_OUTPUT"
+            echo "mintlify_deployment_id=$LAST_DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "Timed out waiting for Mintlify to create a deployment for $SHA" >&2
+            echo "mintlify_status=deployment_not_created" >> "$GITHUB_OUTPUT"
+            echo "mintlify_deployment_id=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Notify Teable webhook
+        if: always()
         env:
           TEABLE_WEBHOOK_URL: ${{ secrets.TEABLE_WEBHOOK_URL }}
           TEABLE_WEBHOOK_TOKEN: ${{ secrets.TEABLE_WEBHOOK_TOKEN }}
           DOCS_BRANCH: ${{ github.event.pull_request.head.ref }}
           DOCS_URL: ${{ steps.wait.outputs.docs_url }}
+          MINTLIFY_STATUS: ${{ steps.wait.outputs.mintlify_status }}
+          MINTLIFY_DEPLOYMENT_ID: ${{ steps.wait.outputs.mintlify_deployment_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
           curl -fsS -X POST \
             "$TEABLE_WEBHOOK_URL" \
             -H "Authorization: Bearer $TEABLE_WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg b "$DOCS_BRANCH" --arg u "$DOCS_URL" '{docs_branch:$b, docs_url:$u}')"
+            -d "$(jq -nc \
+              --arg b "$DOCS_BRANCH" \
+              --arg u "$DOCS_URL" \
+              --arg s "$MINTLIFY_STATUS" \
+              --arg d "$MINTLIFY_DEPLOYMENT_ID" \
+              --arg p "$PR_NUMBER" \
+              --arg r "$PR_URL" \
+              --arg m "$MERGE_SHA" \
+              '{docs_branch:$b, docs_url:$u, mintlify_status:$s, mintlify_deployment_id:$d, pr_number:$p, pr_url:$r, merge_sha:$m}')"
+
+      - name: Fail if Mintlify did not deploy
+        if: steps.wait.outputs.mintlify_status != 'success'
+        run: |
+          echo "Mintlify did not deploy successfully: ${{ steps.wait.outputs.mintlify_status }}" >&2
+          exit 1

--- a/.github/workflows/notify-teable-on-mintlify-deploy.yml
+++ b/.github/workflows/notify-teable-on-mintlify-deploy.yml
@@ -16,6 +16,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Record GitHub merge
+        env:
+          TEABLE_WEBHOOK_URL: ${{ secrets.TEABLE_WEBHOOK_URL }}
+          TEABLE_WEBHOOK_TOKEN: ${{ secrets.TEABLE_WEBHOOK_TOKEN }}
+          DOCS_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST \
+            "$TEABLE_WEBHOOK_URL" \
+            -H "Authorization: Bearer $TEABLE_WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc \
+              --arg b "$DOCS_BRANCH" \
+              --arg s "pending" \
+              --arg p "$PR_NUMBER" \
+              --arg r "$PR_URL" \
+              --arg m "$MERGE_SHA" \
+              --arg t "$MERGED_AT" \
+              '{docs_branch:$b, mintlify_status:$s, pr_number:$p, pr_url:$r, merge_sha:$m, merged_at:$t}')"
+
       - name: Wait for Mintlify deployment
         id: wait
         env:
@@ -88,6 +112,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
         run: |
           set -euo pipefail
           curl -fsS -X POST \
@@ -102,7 +127,8 @@ jobs:
               --arg p "$PR_NUMBER" \
               --arg r "$PR_URL" \
               --arg m "$MERGE_SHA" \
-              '{docs_branch:$b, docs_url:$u, mintlify_status:$s, mintlify_deployment_id:$d, pr_number:$p, pr_url:$r, merge_sha:$m}')"
+              --arg t "$MERGED_AT" \
+              '{docs_branch:$b, docs_url:$u, mintlify_status:$s, mintlify_deployment_id:$d, pr_number:$p, pr_url:$r, merge_sha:$m, merged_at:$t}')"
 
       - name: Fail if Mintlify did not deploy
         if: steps.wait.outputs.mintlify_status != 'success'


### PR DESCRIPTION
## Summary
- Keep `mintlify[bot]` deployment success as the source of truth for a live docs update.
- Send a webhook immediately after PR merge with `mintlify_status: pending`, so Teable records every GitHub merge before Mintlify finishes.
- Detect whether the merged PR changes Mintlify-relevant files before waiting for deployment.
- For content/site changes, send a second webhook after Mintlify resolves with `success`, `deployment_not_created`, `deployment_timeout`, `failure`, or `error`.
- For non-content changes such as workflow-only PRs, send `mintlify_status: not_required` and do not fail the workflow.
- Preserve the existing `docs_branch` and `docs_url` payload fields, and add deployment/PR context fields for troubleshooting.

## Mintlify Relevance
A PR is treated as requiring Mintlify deployment when it changes docs/site inputs:
- `en/`, `zh/`, `images/`, `snippets/`, `api-reference/`
- `docs.json`, `mint.json`, `swagger.json`, `style.css`, `changelog-toc.js`

This PR itself only changes `.github/workflows/notify-teable-on-mintlify-deploy.yml`, so Mintlify skipping deployment is expected. After merge, it should be recorded as `not_required` instead of `deployment_not_created`.

## Teable Automation
- Updated automation `wflM8nejDTw9ZHob2bv` in base `bseu12nLHShtmzYAUYv` and activated it.
- Created table `Docs GitHub Merges` (`tblHUz5XLTYPdpYw2tA`) to track all merged docs PRs.
- Automation now classifies records as `Source Type = Docs Sync` when a matching merged `Docs Sync Runs` row exists, otherwise `manual`.
- Only Docs Sync records with `mintlify_status: success` advance the original `Docs Sync Runs` row to `launch`.

## Checks
- `git diff --check`
- YAML parse check
- Simulated relevance detection for workflow-only and docs/site file paths
- Verified `Docs GitHub Merges.Mintlify Status` includes `not_required`
- Verified the deployment lookup against successful merge commit `6c15f50b9a43f6b6df487f80e2c16babba3d8892` (`success`, deployment `4843526647`)
- Verified the missing-deployment path against PR #144 merge commit `c02105775efe2b4ad0028a0185a24911e85763c4` (`deployment_not_created`)
- Tested the Teable automation draft successfully, then removed the test record and activated the draft
