### PR TITLE
changelog: add GPT-5.6 launch

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -51,7 +51,7 @@
           ]
         },
         "banner": {
-          "content": "🚀 Skills Are Now Available! See our [changelog](/en/changelog) for details.",
+          "content": "🚀 GPT-5.6 Is Now in Teable! See our [changelog](/en/changelog) for details.",
           "dismissible": true
         },
         "tabs": [
@@ -411,7 +411,7 @@
           ]
         },
         "banner": {
-          "content": "🚀 Skills 功能已上线！查看 [更新日志](/zh/changelog) 了解详情。",
+          "content": "🚀 GPT-5.6 已上线 Teable！查看 [更新日志](/zh/changelog) 了解详情。",
           "dismissible": true
         },
         "tabs": [

--- a/en/changelog.mdx
+++ b/en/changelog.mdx
@@ -3,6 +3,21 @@ title: "Changelog 2026"
 rss: true
 ---
 
+<Update label="Jul 10, 2026">
+
+# GPT-5.6 Is Now in Teable
+
+<img loading="lazy" alt="GPT-5.6 Is Now in Teable" src="https://dxshyegpql0u3hra.public.blob.vercel-storage.com/821762d1c05e2814d7370242c8fdf9e8.png" />
+
+GPT-5.6 replaces GPT-5.5 as Teable’s default model, bringing stronger performance to complex app-building and agentic tasks. When working with large tables, documents, and unfamiliar data, it can better understand relationships, plan steps, and complete the same work with fewer actions: app-building steps are reduced by roughly **25%**, tool actions by **35–48%**, and stuck runs by **15%**; million-context reasoning improves by about **70%**, while abstract reasoning on unfamiliar tasks scores about **18x higher**.
+
+Teable now supports the full **GPT-5.6 series**, including **Sol, Terra, and Luna**. This gives Teable AI a stronger model foundation across **AI Chat, App Builder, AI Fields, and automation**, with different model tiers available for different levels of task complexity.
+
+You can try it in Teable now.
+
+</Update>
+
+
 <Update label="Jul 9, 2026">
 
 # History, AI, and Stability Optimization

--- a/zh/changelog.mdx
+++ b/zh/changelog.mdx
@@ -3,6 +3,21 @@ title: "更新日志 2026"
 rss: true
 ---
 
+<Update label="2026-07-10">
+
+# GPT-5.6 已上线 Teable
+
+<img loading="lazy" alt="GPT-5.6 已上线 Teable" src="https://dxshyegpql0u3hra.public.blob.vercel-storage.com/821762d1c05e2814d7370242c8fdf9e8.png" />
+
+GPT-5.6 取代 GPT-5.5 成为 Teable 的默认模型，在复杂应用构建和智能体任务中表现更强。面对大量表格、文档和陌生数据，它能更好地理清关系、规划步骤，并用更少操作完成同样的工作：应用构建步骤减少约 **25%**，工具操作减少 **35–48%**，卡住情况减少 **15%**；百万级上下文推理提升约 **70%**，陌生任务中的抽象推理测试得分约为原来的 **18 倍**。
+
+Teable 现在支持 **GPT-5.6 全系列**，包括 **Sol、Terra 和 Luna**。这让 Teable AI 在 **AI 聊天、应用构建器、AI 字段和自动化** 中拥有了更强的模型基础，并可以根据任务复杂度使用不同档位的模型能力。
+
+现在就可以在 Teable 中体验它。
+
+</Update>
+
+
 <Update label="2026-07-09">
 
 # 历史、AI与稳定性优化


### PR DESCRIPTION
## Changes
- Added GPT-5.6 Is Now in Teable changelog entries for EN and ZH
- Updated Mintlify banners for EN, ZH, and root

## Preview
- https://help.teable.ai/en/changelog#jul-10-2026