### PR TITLE
changelog: clarify Teable 3.0 Product Hunt link

### DIFF
--- a/en/changelog.mdx
+++ b/en/changelog.mdx
@@ -45,7 +45,7 @@ Whether you’re a small business or an enterprise, Teable helps your team becom
 
 ## 🙌 Support Our Product Hunt Launch
 
-If you like what we’re building, your upvote would mean a lot to us: **[Product Hunt](https://www.producthunt.com/products/teable-4)**
+If you like what we’re building, your upvote would mean a lot to us: **[Teable 3.0 on Product Hunt](https://www.producthunt.com/products/teable-4)**
 
 </Update>
 


### PR DESCRIPTION
Updates the Teable 3.0 Product Hunt link text to **Teable 3.0 on Product Hunt** while preserving the approved destination URL.