### PR TITLE
fix: reserve Mintlify nav logo dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,12 @@
 /* Custom styles for Teable documentation */
 
+/* Reserve the Mintlify navigation logo's rendered size before the image loads. */
+.nav-logo {
+  width: 108px;
+  height: 28px;
+  object-fit: contain;
+}
+
 /* Hide changelog left date column, expand content */
 .update-container > div:first-child {
   display: none !important;


### PR DESCRIPTION
## What changed

- Reserve the existing 108 × 28 px space for Mintlify's navigation logo before the image loads.
- Keep the current visual size and use `object-fit: contain` for both light and dark logos.

## Why

Google Search Console groups Help Center desktop pages under CLS issues. Current Lighthouse runs no longer reproduce a layout shift, but both mobile and desktop identify the Mintlify navigation logo as lacking explicit dimensions. Reserving its current rendered size removes that remaining deterministic risk without changing document content or Mintlify navigation behavior.

## Impact

- CSS-only change in the Mintlify docs repository.
- No content, navigation, banner, or JavaScript changes.
- The existing logo renders at 108 × 28 px on both mobile and desktop, so this does not enlarge or reflow the mobile header.

## Validation

- `mintlify validate`: passed.
- Local Lighthouse, AI Overview, mobile: CLS 0; no layout shifts; no unsized images.
- Local Lighthouse, AI Overview, desktop: CLS 0; no layout shifts; no unsized images.

Google Search Console field data uses a rolling real-user window, so the reported URL groups will need monitoring after deployment.
