### PR TITLE
Simplify migration guide comparison links

### DIFF
--- a/en/basic/ai/connect-everything/migrate-airtable.mdx
+++ b/en/basic/ai/connect-everything/migrate-airtable.mdx
@@ -21,6 +21,6 @@ In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select the **Connect
 Migration coverage depends on the Airtable API and the token's scopes and resource access. Revoke the token after the migration is complete.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs Airtable](https://teable.ai/compare/airtable-alternative), then see how migrated project bases become live plans, current status, early risk signals, and automatic follow-up in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs Airtable](https://teable.ai/compare/airtable-alternative).

--- a/en/basic/ai/connect-everything/migrate-airtable.mdx
+++ b/en/basic/ai/connect-everything/migrate-airtable.mdx
@@ -23,4 +23,4 @@ Migration coverage depends on the Airtable API and the token's scopes and resour
 
 ## Compare before you switch
 
-[Compare Teable vs Airtable](https://teable.ai/compare/airtable-alternative).
+Review the differences in data modeling, automation, AI, deployment, and pricing in the [Teable vs Airtable comparison](https://teable.ai/compare/airtable-alternative).

--- a/en/basic/ai/connect-everything/migrate-baserow.mdx
+++ b/en/basic/ai/connect-everything/migrate-baserow.mdx
@@ -23,4 +23,4 @@ Migration coverage depends on the Baserow API and the tables and permissions ass
 
 ## Compare before you switch
 
-[Compare Teable vs Baserow](https://teable.ai/compare/baserow-alternative).
+Review the differences in data modeling, automation, AI, deployment, and pricing in the [Teable vs Baserow comparison](https://teable.ai/compare/baserow-alternative).

--- a/en/basic/ai/connect-everything/migrate-baserow.mdx
+++ b/en/basic/ai/connect-everything/migrate-baserow.mdx
@@ -21,6 +21,6 @@ Use **Connect Everything** in [Teable AI Chat](/en/basic/ai/ai-chat) to connect 
 Migration coverage depends on the Baserow API and the tables and permissions assigned to the database token.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs Baserow](https://teable.ai/compare/baserow-alternative), then see how Teable turns migrated business data into workflows and purpose-built interfaces with its [no-code app builder](https://teable.ai/no-code-app-builder).
+[Compare Teable vs Baserow](https://teable.ai/compare/baserow-alternative).

--- a/en/basic/ai/connect-everything/migrate-clickup.mdx
+++ b/en/basic/ai/connect-everything/migrate-clickup.mdx
@@ -9,7 +9,6 @@ keywords:
   - ClickUp alternative
   - ClickUp API migration
   - ClickUp token migration
-  - AI project management
 ---
 
 In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Everything**, then provide your ClickUp personal API token. Teable AI can use that authorized connection to migrate API-accessible Workspaces, Spaces, Folders, Lists, tasks, subtasks, fields, comments, and attachments into Teable, so you do not have to rebuild the workspace manually.
@@ -25,6 +24,6 @@ In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Eve
 Migration coverage depends on the ClickUp API, plan limits, rate limits, and token-authorized resources. Dashboards, automations, permissions, and unsupported assets may require separate handling. Rotate a migration-only credential after the migration is complete.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs ClickUp](https://teable.ai/compare/clickup-alternative), then see how Teable connects project data, live status, early risk signals, teams, and AI agents in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs ClickUp](https://teable.ai/compare/clickup-alternative).

--- a/en/basic/ai/connect-everything/migrate-clickup.mdx
+++ b/en/basic/ai/connect-everything/migrate-clickup.mdx
@@ -26,4 +26,4 @@ Migration coverage depends on the ClickUp API, plan limits, rate limits, and tok
 
 ## Compare before you switch
 
-[Compare Teable vs ClickUp](https://teable.ai/compare/clickup-alternative).
+Review the differences in project structure, workflow automation, reporting, AI, and pricing in the [Teable vs ClickUp comparison](https://teable.ai/compare/clickup-alternative).

--- a/en/basic/ai/connect-everything/migrate-jira.mdx
+++ b/en/basic/ai/connect-everything/migrate-jira.mdx
@@ -9,7 +9,6 @@ keywords:
   - Jira alternative
   - Jira API migration
   - Jira token migration
-  - AI project management
 ---
 
 In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Everything**, then provide your Jira Cloud site URL, Atlassian account email, and API token. Teable AI can use that authorized connection to migrate API-accessible projects, work items, fields, users, statuses, sprints, comments, relationships, and attachments into Teable, so you do not have to rebuild the workspace manually.
@@ -25,6 +24,6 @@ In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Eve
 Migration coverage depends on the Jira API, account permissions, and token access. Jira automation rules, Marketplace app data, dashboards, and permission schemes may require separate handling. Revoke a migration-only token after the migration is complete.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs Jira](https://teable.ai/compare/jira-alternative), then see how Teable connects project data, live status, early risk signals, teams, and AI agents in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs Jira](https://teable.ai/compare/jira-alternative).

--- a/en/basic/ai/connect-everything/migrate-jira.mdx
+++ b/en/basic/ai/connect-everything/migrate-jira.mdx
@@ -26,4 +26,4 @@ Migration coverage depends on the Jira API, account permissions, and token acces
 
 ## Compare before you switch
 
-[Compare Teable vs Jira](https://teable.ai/compare/jira-alternative).
+Review the differences in project structure, workflow automation, reporting, AI, and pricing in the [Teable vs Jira comparison](https://teable.ai/compare/jira-alternative).

--- a/en/basic/ai/connect-everything/migrate-monday.mdx
+++ b/en/basic/ai/connect-everything/migrate-monday.mdx
@@ -9,7 +9,6 @@ keywords:
   - monday.com alternative
   - monday.com API migration
   - monday.com token migration
-  - AI project management
 ---
 
 In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Everything**, then provide your monday.com personal API token. Teable AI can use that authorized connection to migrate API-accessible workspaces, boards, groups, items, subitems, columns, users, updates, and files into Teable, so you do not have to rebuild the workspace manually.
@@ -25,6 +24,6 @@ In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Eve
 Migration coverage depends on the monday.com API and the user's token permissions. Dashboards, automation recipes, integrations, apps, and inaccessible private boards may require separate handling. Rotate a migration-only credential after the migration is complete.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs monday.com](https://teable.ai/compare/monday-alternative), then see how Teable connects project data, live status, early risk signals, teams, and AI agents in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs monday.com](https://teable.ai/compare/monday-alternative).

--- a/en/basic/ai/connect-everything/migrate-monday.mdx
+++ b/en/basic/ai/connect-everything/migrate-monday.mdx
@@ -26,4 +26,4 @@ Migration coverage depends on the monday.com API and the user's token permission
 
 ## Compare before you switch
 
-[Compare Teable vs monday.com](https://teable.ai/compare/monday-alternative).
+Review the differences in project structure, workflow automation, reporting, AI, and pricing in the [Teable vs monday.com comparison](https://teable.ai/compare/monday-alternative).

--- a/en/basic/ai/connect-everything/migrate-nocodb.mdx
+++ b/en/basic/ai/connect-everything/migrate-nocodb.mdx
@@ -21,6 +21,6 @@ Use **Connect Everything** in [Teable AI Chat](/en/basic/ai/ai-chat) to connect 
 Use a fine-grained API token when available. Migration coverage depends on the NocoDB API and the token's base access and permissions.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs NocoDB](https://teable.ai/compare/nocodb-alternative), then see how Teable turns migrated database records into working apps with its [AI app builder](https://teable.ai/ai-app-builder).
+[Compare Teable vs NocoDB](https://teable.ai/compare/nocodb-alternative).

--- a/en/basic/ai/connect-everything/migrate-nocodb.mdx
+++ b/en/basic/ai/connect-everything/migrate-nocodb.mdx
@@ -23,4 +23,4 @@ Use a fine-grained API token when available. Migration coverage depends on the N
 
 ## Compare before you switch
 
-[Compare Teable vs NocoDB](https://teable.ai/compare/nocodb-alternative).
+Review the differences in data modeling, automation, AI, deployment, and pricing in the [Teable vs NocoDB comparison](https://teable.ai/compare/nocodb-alternative).

--- a/en/basic/ai/connect-everything/migrate-smartsheet.mdx
+++ b/en/basic/ai/connect-everything/migrate-smartsheet.mdx
@@ -26,4 +26,4 @@ Migration coverage depends on the Smartsheet API, account permissions, and accou
 
 ## Compare before you switch
 
-[Compare Teable vs Smartsheet](https://teable.ai/compare/smartsheet-alternative).
+Review the differences in project structure, workflow automation, reporting, AI, and pricing in the [Teable vs Smartsheet comparison](https://teable.ai/compare/smartsheet-alternative).

--- a/en/basic/ai/connect-everything/migrate-smartsheet.mdx
+++ b/en/basic/ai/connect-everything/migrate-smartsheet.mdx
@@ -9,7 +9,6 @@ keywords:
   - Smartsheet alternative
   - Smartsheet API migration
   - Smartsheet token migration
-  - AI project management
 ---
 
 In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Everything**, then provide your Smartsheet API access token and account environment. Teable AI can use that authorized connection to migrate API-accessible workspaces, folders, sheets, reports, columns, rows, discussions, and attachments into Teable, so you do not have to rebuild the workspace manually.
@@ -25,6 +24,6 @@ In [**Teable AI Chat**](/en/basic/ai/ai-chat), type `/` and select **Connect Eve
 Migration coverage depends on the Smartsheet API, account permissions, and account environment. Tokens are not interchangeable between Smartsheet environments. Revoke a migration-only token after the migration is complete.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs Smartsheet](https://teable.ai/compare/smartsheet-alternative), then see how Teable connects project data, live status, early risk signals, teams, and AI agents in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs Smartsheet](https://teable.ai/compare/smartsheet-alternative).

--- a/en/basic/ai/connect-everything/migrate-smartsuite.mdx
+++ b/en/basic/ai/connect-everything/migrate-smartsuite.mdx
@@ -23,4 +23,4 @@ The API key uses the permissions of the SmartSuite member who created it. Use an
 
 ## Compare before you switch
 
-[Compare Teable vs SmartSuite](https://teable.ai/compare/smartsuite-alternative).
+Review the differences in data modeling, automation, AI, deployment, and pricing in the [Teable vs SmartSuite comparison](https://teable.ai/compare/smartsuite-alternative).

--- a/en/basic/ai/connect-everything/migrate-smartsuite.mdx
+++ b/en/basic/ai/connect-everything/migrate-smartsuite.mdx
@@ -21,6 +21,6 @@ Use **Connect Everything** in [Teable AI Chat](/en/basic/ai/ai-chat) to connect 
 The API key uses the permissions of the SmartSuite member who created it. Use an account with only the access required for the migration.
 </Note>
 
-## Decide and continue
+## Compare before you switch
 
-[Compare Teable vs SmartSuite](https://teable.ai/compare/smartsuite-alternative), then see how Teable connects migrated project data, live status, teams, and AI agents in [AI project management](https://teable.ai/ai-project-management).
+[Compare Teable vs SmartSuite](https://teable.ai/compare/smartsuite-alternative).


### PR DESCRIPTION
## Summary
- keep one product-specific comparison link in each migration guide
- remove forced product-page cross-links from migration content
- remove the broad AI project management keyword from tool-specific migration metadata

## Validation
- erro mintlify is not supported on node versions 25+ (current version 25.9.0).
    Please downgrade to an LTS node version.
- all eight comparison URLs return HTTP 200
- targeted pages contain no AI project management or app-builder cross-links

Note: the repository-wide broken-link checker still reports pre-existing unrelated links in archive and API documentation; none are in these eight migration guides.