### PR TITLE
docs: update banner for new language support

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -131,7 +131,7 @@
           ]
         },
         "banner": {
-          "content": "🌍 Teable now supports Arabic, Italian, and Spanish! See our [changelog](/en/changelog#aug-25-2026) for details.",
+          "content": "🚀 Teable now supports Arabic, Italian, and Spanish! See our [changelog](/en/changelog#aug-25-2026) for details.",
           "dismissible": true
         },
         "tabs": [
@@ -504,7 +504,7 @@
           ]
         },
         "banner": {
-          "content": "🌍 Teable 现已支持阿拉伯语、意大利语和西班牙语！查看[更新日志](/zh/changelog#2026-08-25)了解详情。",
+          "content": "🚀 Teable 现已支持阿拉伯语、意大利语和西班牙语！查看[更新日志](/zh/changelog#2026-08-25)了解详情。",
           "dismissible": true
         },
         "tabs": [

--- a/docs.json
+++ b/docs.json
@@ -131,7 +131,7 @@
           ]
         },
         "banner": {
-          "content": "🚀 Introducing Teable 3.0: The AI Spreadsheet for Business! See our [changelog](/en/changelog) for details.",
+          "content": "🌍 Teable now supports Arabic, Italian, and Spanish! See our [changelog](/en/changelog#aug-25-2026) for details.",
           "dismissible": true
         },
         "tabs": [
@@ -504,7 +504,7 @@
           ]
         },
         "banner": {
-          "content": "🚀 Teable 3.0 正式发布！查看 [更新日志](/zh/changelog) 了解详情。",
+          "content": "🌍 Teable 现已支持阿拉伯语、意大利语和西班牙语！查看[更新日志](/zh/changelog#2026-08-25)了解详情。",
           "dismissible": true
         },
         "tabs": [


### PR DESCRIPTION
## Summary
- replace the Teable 3.0 docs banner with the Arabic, Italian, and Spanish language announcement
- link English and Chinese banners directly to the Aug 25 changelog entry

## Verification
- `jq empty docs.json`
- `git diff --check`