### PR TITLE
docs(api): set the record list take limit to 100

### DIFF
--- a/en/api-doc/overview.mdx
+++ b/en/api-doc/overview.mdx
@@ -41,7 +41,7 @@ Both Personal Access Tokens and OAuth tokens are permission-scoped. If you get a
 
 Many list endpoints support:
 
-- `take`: number of items to return (some endpoints cap this, e.g. records max 1000)
+- `take`: number of items to return (some endpoints cap this, e.g. records max 100 per request, so page with `skip`)
 - `skip`: number of items to skip
 
 ## Field keys & cell format

--- a/en/api-doc/record/get.mdx
+++ b/en/api-doc/record/get.mdx
@@ -19,7 +19,7 @@ All parameters are optional
 </ParamField>
 
 <ParamField query="take" type="number">
-  Specifies the number of records to retrieve, maximum value is 1000.
+  Specifies the number of records to retrieve, maximum value is 100. To read more records, page through the data with `skip` and `take` (see [Pagination](/en/api-doc/overview)).
 </ParamField>
 
 <ParamField query="skip" type="number">

--- a/zh/api-doc/overview.mdx
+++ b/zh/api-doc/overview.mdx
@@ -41,7 +41,7 @@ curl -H 'Authorization: Bearer __token__' \
 
 很多列表接口支持：
 
-- `take`：返回条数（部分接口存在上限，例如记录查询最多 1000）
+- `take`：返回条数（部分接口存在上限，例如记录查询单次最多 100 条，请配合 `skip` 分页）
 - `skip`：跳过条数
 
 ## 字段键与单元格格式（fieldKeyType / cellFormat）

--- a/zh/api-doc/record/get.mdx
+++ b/zh/api-doc/record/get.mdx
@@ -20,7 +20,7 @@ tableId (string): 表的唯一标识符[（如何获取）](/zh/api-doc/get-id#t
 </ParamField>
 
 <ParamField query="take" type="number">
-  指定要获取的记录数量，最大值为 1000。
+  指定要获取的记录数量，最大值为 100。需要读取更多数据时，请配合 `skip` 与 `take` 分页获取（见[分页说明](/zh/api-doc/overview)）。
 </ParamField>
 
 <ParamField query="skip" type="number">


### PR DESCRIPTION
## Summary
- `GET /api/table/{tableId}/record` now caps `take` at 100 per request on Teable Cloud (teableio/teable-ee#3308).
- Update the `take` parameter description on the record list page and the pagination note in the API overview (en + zh) to state the 100 limit and point readers to `skip`/`take` pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)